### PR TITLE
`.gitignore` の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/oba/video/*


### PR DESCRIPTION
resolve #6 

とりあえず`AOPA/oba/video`の下は全て無視することにしました．
そこには，実験用の動画ファイルを入れておくことにします．